### PR TITLE
Fixed persistent attributes in PRIVMSG and NOTICE

### DIFF
--- a/includes/replies.h
+++ b/includes/replies.h
@@ -12,7 +12,6 @@
 #define RPL_CHANNELMODEIS(target, modes, param) "324 * " + (target) + " " + (modes) + param + "\r\n" //324
 #define	RPL_NOTOPIC(channel) "331 * " + (channel) + " :No topic is set \r\n" //331
 #define	RPL_TOPIC(channel, topic) "332 * " + (channel) + " :" + (topic) + "\r\n"//332
-#define RPL_INVITING(channel,nick) "341 * " + (channel) + " " + (nick) + "\r\n" //341
 #define RPL_NAMREPLY(hostname, nick, channel, users) ":" + (hostname) + " 353 " + (nick) + " = " + (channel) + " :" + users +  "\r\n" //353
 #define RPL_INVITING(prefix, targetnick, channel) ":" + (prefix) + " INVITE " + (targetnick) + " " + (channel) + "\r\n"
 
@@ -26,6 +25,8 @@
 #define CMD_PART(prefix, channel, message) ":" + (prefix) + " PART " + (channel) + " :" + (message) + "\r\n"
 #define CMD_PART_NO_MSG(prefix, channel) ":" + (prefix) + " PART " + (channel) + "\r\n"
 #define CMD_INVITE(hostname, client, target, channel) ":" + (hostname) + " 341 " + (client) + " " + (target) + " :" + (channel) + "\r\n"
+// FIXME: the RPL_INVITING and CMD_INVITE are curently inverted; 
+//  the 341 reply code is meant to be sent to the inviting client, not the invited client
 
 /* Error Messages */
 #define ERR_NOSUCHNICK(nickname) "401 * " + (nickname) + " :No such nickname" + "\r\n" //401

--- a/srcs/commands/Mode.cpp
+++ b/srcs/commands/Mode.cpp
@@ -100,7 +100,7 @@ bool	Mode::validate(const Message& msg) {
 					}
 					if (mode.c_str()[1] == 'i') {
 						_server->getChannelPtr(target)->setMemberModes(_server->getClientPtr(user), INV, removeMode);
-						msg._client->reply(RPL_INVITING(target, user));
+						// msg._client->reply(RPL_INVITING(target, user));
 					}
 					if (mode.c_str()[1] == 'v') {
 						_server->getChannelPtr(target)->setMemberModes(_server->getClientPtr(user), VOICE, removeMode);

--- a/srcs/commands/Notice.cpp
+++ b/srcs/commands/Notice.cpp
@@ -18,6 +18,7 @@ bool	Notice::validate(const Message& msg) {
 
     _target = args.at(0);
     args.erase(args.begin());
+	_targetIsChannel = false;
     if(_target.at(0) == '#')
     {
         _targetIsChannel = true;
@@ -25,7 +26,6 @@ bool	Notice::validate(const Message& msg) {
 			return false;
 		return true;
     }
-	_targetIsChannel = false;
 	if (!_server->doesNickExist(_target))
 		return false;
     return true;
@@ -48,6 +48,9 @@ void	Notice::execute(const Message& msg)
 
 void	Notice::_buildMessage(const Message& msg)
 {
+	/* Clear the message buffer, since the Privmsg object never gets out of scope */
+	_message.clear();
+	
 	size_t	nb_args = msg.getMiddle().size();
 	
 	/* If the message was a single word, some clients (e.g. Limechat) do not

--- a/srcs/commands/Privmsg.cpp
+++ b/srcs/commands/Privmsg.cpp
@@ -25,6 +25,8 @@ bool Privmsg::validate(const Message& msg) {
     }
     _target = args.at(0);
     args.erase(args.begin());
+
+    _targetIsChannel = false;
     if (_target.at(0) == '#')
     {
         _targetIsChannel = true;
@@ -41,7 +43,6 @@ bool Privmsg::validate(const Message& msg) {
         return true;
     }
 
-    _targetIsChannel = false;
     if (!_server->doesNickExist(_target))
     {
         msg._client->reply(ERR_NOSUCHNICK(_target));
@@ -72,6 +73,9 @@ void	Privmsg::execute(const Message& msg)
 
 void    Privmsg::_buildMessage(const Message& msg)
 {
+    /* Clear the message buffer, since the Privmsg object never gets out of scope */
+    _message.clear();
+    
 	size_t	nb_args = msg.getMiddle().size();
 	
 	/* If the message was a single word, some clients (e.g. Limechat) do not


### PR DESCRIPTION
The commands being allocated objects, they never get out of scope, so the targets were always piling on